### PR TITLE
fix the toast hiding too soon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,11 +22,13 @@
           const clipboard = new ClipboardJS('.permalink button');
           const toast = document.querySelector('.toast');
 
+	  let timeout = -1;
           clipboard.on('success', function(e) {
+            clearTimeout(timeout);
             toast.classList.add('open');
-            setTimeout(function() {
+            timeout = setTimeout(function() {
             	toast.classList.remove('open')
-            }, 2000)
+            }, 2000);
           });
         }
 


### PR DESCRIPTION
 when clicking copy to clipboard multiple times, because the timeout is not being cleared, it hides the toast too fast.


didn't 🎩 